### PR TITLE
Updated clang-format rules and added tool for running clang-format.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,14 +1,23 @@
+# This file defines formatting options for clang-format tool.
+# See https://clang.llvm.org/docs/ClangFormatStyleOptions.html for options.
+
 BasedOnStyle: LLVM
 
-Language:        Cpp
-IndentWidth: 2
+Language: Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: DontAlign
+AlignEscapedNewlines: DontAlign
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
+AlwaysBreakTemplateDeclarations: true
+BreakBeforeBraces: Attach
+ColumnLimit: 100
+DerivePointerAlignment: false
+IndentCaseLabels: true
+IndentWidth: 4
+KeepEmptyLinesAtTheStartOfBlocks: false
+NamespaceIndentation: All
 PointerAlignment: Left
 SortIncludes: false
-AlwaysBreakTemplateDeclarations: true
-BreakBeforeBraces: Custom
-BraceWrapping:
-  AfterClass:      false
-  AfterStruct:     true
-  AfterFunction:   false
-  BeforeCatch:     false
-  BeforeElse:      false
+TabWidth: 4
+UseTab: Never

--- a/format-sources
+++ b/format-sources
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Formatting teoccl source code."
+./tools/clang-format-all ./src
+
+echo "Formatting teoccl tests."
+./tools/clang-format-all ./tests

--- a/src/hash.c
+++ b/src/hash.c
@@ -47,7 +47,7 @@
 // See definition at: http://www.azillionmonkeys.com/qed/hash.html
 
 uint32_t teoHashSuperFast(const char * data, int len) {
-    uint32_t hash = len, tmp;
+    uint32_t hash = len;
     int rem;
 
     if (len <= 0 || data == NULL) return 0;
@@ -58,7 +58,7 @@ uint32_t teoHashSuperFast(const char * data, int len) {
     /* Main loop */
     for (; len > 0; len--) {
         hash += get16bits(data);
-        tmp = (get16bits(data + 2) << 11) ^ hash;
+        uint32_t tmp = (get16bits(data + 2) << 11) ^ hash;
         hash = (hash << 16) ^ tmp;
         data += 2 * sizeof (uint16_t);
         hash += hash >> 11;

--- a/src/map.c
+++ b/src/map.c
@@ -224,9 +224,9 @@ static void *_teoMapGet(teoMap *map, void *key, size_t key_length,
 
     int idx = hash % map->hash_map_size;
     teoMapElementData *htd;
-    teoQueueData *tqd;
     teoQueueIterator *it = teoQueueIteratorNew(map->q[idx]);
     if(it != NULL) {
+      teoQueueData *tqd;
       while((tqd = teoQueueIteratorNext(it))) {
 
         htd = (teoMapElementData *)tqd->data;

--- a/tools/clang-format-all
+++ b/tools/clang-format-all
@@ -1,0 +1,89 @@
+#!/bin/bash
+#
+# clang-format-all: a tool to run clang-format on an entire project
+# Copyright (C) 2016 Evan Klitzke <evan@eklitzke.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# This is modified version of the bash script by Evan Klitzke
+# https://github.com/eklitzke/clang-format-all
+
+function usage {
+    echo "Usage: $0 DIR..."
+    exit 1
+}
+
+if [ $# -eq 0 ]; then
+    usage
+fi
+
+# Variable that will hold the name of the clang-format command
+FMT=""
+
+# Some distros just call it clang-format. Others (e.g. Ubuntu) are insistent
+# that the version number be part of the command. We prefer clang-format if
+# that's present, otherwise we work backwards from highest version to lowest
+# version.
+for clangfmt in clang-format{-{9,8,7,6,5,4,3}.{9,8,7,6,5,4,3,2,1,0},}; do
+    if which "$clangfmt" &>/dev/null; then
+        FMT="$clangfmt"
+        break
+    fi
+done
+
+# Check if we found a working clang-format
+if [ -z "$FMT" ]; then
+    echo "failed to find clang-format"
+    exit 1
+fi
+
+# Check all of the arguments first to make sure they're all directories
+for dir in "$@"; do
+    if [ ! -d "${dir}" ]; then
+        echo "${dir} is not a directory"
+        usage
+    fi
+done
+
+# Find a dominating file, starting from a given directory and going up.
+find-dominating-file() {
+    if [ -r "$1"/"$2" ]; then
+        return 0
+    fi
+    if [ "$1" = "/" ]; then
+        return 1
+    fi
+    find-dominating-file "$(realpath "$1"/..)" "$2"
+    return $?
+}
+
+"${FMT}" --version
+
+# Run clang-format -i on all of the things
+for dir in "$@"; do
+    pushd "${dir}" &>/dev/null
+    if ! find-dominating-file . .clang-format; then
+        echo "Failed to find dominating .clang-format starting at $PWD"
+        continue
+    fi
+    find . \
+         \( -name '*.c' \
+         -o -name '*.cc' \
+         -o -name '*.cpp' \
+         -o -name '*.h' \
+         -o -name '*.hh' \
+         -o -name '*.hpp' \) \
+         -exec "${FMT}" -i '{}' \;
+    popd &>/dev/null
+done


### PR DESCRIPTION
I've updated the rules for clang-format to fit our current style as best as possible.
Also I've added a tool to run `clang-format -i` on all sources.

To format source, execute `./format-sources` command in the root directory of the project.

Source code is not formatted yet.

Please review that style match your expectations @angelskieglazki .
