### PR TITLE
Buffer Types and Constantness

### DIFF
--- a/include/teoccl/hash.h
+++ b/include/teoccl/hash.h
@@ -37,13 +37,9 @@
 extern "C" {
 #endif
 
-typedef unsigned long int ub4; /* unsigned 4-byte quantities */
-typedef unsigned char ub1; /* unsigned 1-byte quantities */
-
-uint32_t teoHashSuperFast (const char * data, int len);
-ub4 teoHashFast(ub1 *k, ub4 length, ub4 initval); /* the previous hash,
-                                                     or an arbitrary value
-                                                   */
+uint32_t teoHashSuperFast(const uint8_t* data, int len);
+/* the previous hash, or an arbitrary value */
+uint32_t teoHashFast(register const uint8_t* k, register uint32_t length, register uint32_t initval);
 
 #ifdef __cplusplus
 }

--- a/include/teoccl/map.h
+++ b/include/teoccl/map.h
@@ -60,7 +60,7 @@ typedef struct teoMapElementData {
     uint32_t hash;
     size_t key_length;
     size_t data_length;
-    char data[]; // Key + Data
+    uint8_t data[]; // Key + Data
 
 } teoMapElementData;
 
@@ -82,7 +82,7 @@ typedef struct teoMapIterator {
  *
  * @return
  */
-void *teoMapGetFirst(teoMap *map, size_t *data_length);
+uint8_t *teoMapGetFirst(teoMap *map, size_t *data_length);
 
 /**
  * Get number of elements in TR-UPD map
@@ -130,7 +130,7 @@ void teoMapClear(teoMap *map);
  *
  * @return
  */
-void *teoMapAdd(teoMap *map, void *key, size_t key_length, void *data,
+uint8_t *teoMapAdd(teoMap *map, const uint8_t *key, size_t key_length, const uint8_t *data,
   size_t data_length);
 
 
@@ -144,12 +144,12 @@ void *teoMapAdd(teoMap *map, void *key, size_t key_length, void *data,
  * @return Data of added key or (void*)-1 at error
  */
 static
-inline void *teoMapAddStr(teoMap *map, const char *key, void *data,
+inline uint8_t *teoMapAddStr(teoMap *map, const char *key, const uint8_t *data,
         size_t data_length) {
-    return teoMapAdd(map, (void*)key, strlen(key) + 1, data, data_length);
+    return teoMapAdd(map, (const uint8_t*)key, strlen(key) + 1, data, data_length);
 }
 
-void *teoMapGet(teoMap *map, void *key, size_t key_length,
+uint8_t *teoMapGet(teoMap *map, const uint8_t *key, size_t key_length,
   size_t *data_length);
 
 /**
@@ -162,11 +162,11 @@ void *teoMapGet(teoMap *map, void *key, size_t key_length,
  * @return Data of selected key (may be NULL) or (void*)-1 if not found
  */
 static
-inline void *teoMapGetStr(teoMap *map, const char *key, size_t *data_length) {
-    return teoMapGet(map, (void *)key, strlen(key) + 1, data_length);
+inline uint8_t *teoMapGetStr(teoMap *map, const char *key, size_t *data_length) {
+    return teoMapGet(map, (const uint8_t*)key, strlen(key) + 1, data_length);
 }
 
-int teoMapDelete(teoMap *map, void *key, size_t key_length);
+int teoMapDelete(teoMap *map, const uint8_t *key, size_t key_length);
 
 /**
  * Delete keys element from map when key is cstring
@@ -177,7 +177,7 @@ int teoMapDelete(teoMap *map, void *key, size_t key_length);
  */
 static
 inline int teoMapDeleteStr(teoMap *map, const char *key) {
-    return teoMapDelete(map, (void *)key, strlen(key) + 1);
+    return teoMapDelete(map, (const uint8_t*)key, strlen(key) + 1);
 }
 
 teoMapIterator *teoMapIteratorNew(teoMap *map);
@@ -206,7 +206,7 @@ inline teoMapElementData *teoMapIteratorElement(teoMapIterator *map_it) {
  * @return Pointer to key
  */
 static
-inline void *teoMapIteratorElementKey(teoMapElementData *el,
+inline uint8_t *teoMapIteratorElementKey(teoMapElementData *el,
         size_t *key_length) {
     if(key_length) *key_length = el->key_length;
     return el->data;
@@ -219,7 +219,7 @@ inline void *teoMapIteratorElementKey(teoMapElementData *el,
  * @return Pointer to data
  */
 static
-inline void *teoMapIteratorElementData(teoMapElementData *el,
+inline uint8_t *teoMapIteratorElementData(teoMapElementData *el,
         size_t *data_length) {
     if(data_length) *data_length = el->data_length;
     return el->data + el->key_length;

--- a/include/teoccl/map.hpp
+++ b/include/teoccl/map.hpp
@@ -71,54 +71,56 @@ namespace teo {
 
 
     // add
-    inline void *add(void *key, size_t key_length, void *data,
-        size_t data_length) {
+    inline void *add(const uint8_t *key, size_t key_length,
+        const uint8_t *data, size_t data_length) {
       return teoMapAdd(map, key, key_length, data, data_length);
     }
 
     inline void *add(const std::string& key, const std::string& data) {
-      return add((void *)key.c_str(), key.size() + 1, (void *)data.c_str(),
-          data.size() + 1);
+      return add((const uint8_t *)key.c_str(), key.size() + 1,
+          (const uint8_t *)data.c_str(), data.size() + 1);
     }
 
     template<typename D>
     void *add(const std::string& key, const D& data) {
-      return add((void*)key.c_str(), key.size() + 1, (void *)&data, sizeof(D));
+      return add((const uint8_t*)key.c_str(), key.size() + 1,
+          (const uint8_t *)&data, sizeof(D));
     }
 
     template<typename K, typename D>
     void *add(const K& key, const D& data) {
-      return add((void*)&key, sizeof(K), (void *)&data, sizeof(D));
+      return add((const uint8_t*)&key, sizeof(K),
+            (const uint8_t *)&data, sizeof(D));
     }
 
 
     // get
-    inline void *get(void *key, size_t key_length, size_t *data_length) {
+    inline void *get(const uint8_t *key, size_t key_length, size_t *data_length) {
       return teoMapGet(map, key, key_length, data_length);
     }
 
     inline void *get(const std::string& key, size_t *data_length) {
-      return get((void *)key.c_str(), key.size() + 1, data_length);
+      return get((const uint8_t *)key.c_str(), key.size() + 1, data_length);
     }
 
     template<typename K>
     void *get(const K& key, size_t *data_length) {
-      return get((void *)&key, sizeof(K), data_length);
+      return get((const uint8_t *)&key, sizeof(K), data_length);
     }
 
 
     // delete
-    inline int del(void *key, size_t key_length) {
+    inline int del(const uint8_t *key, size_t key_length) {
       return teoMapDelete(map, key, key_length);
     }
 
     inline int del(const std::string& key) {
-      return del((void *)key.c_str(), key.size() + 1);
+      return del((const uint8_t *)key.c_str(), key.size() + 1);
     }
 
     template<typename K>
     int del(const K& key) {
-      return del((void *)&key, sizeof(K));
+      return del((const uint8_t *)&key, sizeof(K));
     }
 
 

--- a/src/teoccl/algs/lru_cache.c
+++ b/src/teoccl/algs/lru_cache.c
@@ -39,7 +39,7 @@ void cclLruRefer(ccl_lru_cache_t *lru, void *data, size_t data_len)
     }
 
     teoQueueAddTop(lru->lru_que, data, data_len);
-    teoMapAdd(lru->lru_hash, data, data_len, &lru->lru_que->first, sizeof(lru->lru_que->first));
+    teoMapAdd(lru->lru_hash, data, data_len, (uint8_t*)&lru->lru_que->first, sizeof(lru->lru_que->first));
 }
 
 void cclLruForeach(ccl_lru_cache_t *lru, void (*fn)(const void *const data))

--- a/src/teoccl/hash.c
+++ b/src/teoccl/hash.c
@@ -46,7 +46,7 @@
 
 // See definition at: http://www.azillionmonkeys.com/qed/hash.html
 
-uint32_t teoHashSuperFast(const char * data, int len) {
+uint32_t teoHashSuperFast(const uint8_t* data, int len) {
     uint32_t hash = len;
     int rem;
 
@@ -91,10 +91,7 @@ uint32_t teoHashSuperFast(const char * data, int len) {
     return hash;
 }
 
-//typedef unsigned long int ub4; /* unsigned 4-byte quantities */
-//typedef unsigned char ub1; /* unsigned 1-byte quantities */
-
-#define hashsize(n) ((ub4)1<<(n))
+#define hashsize(n) ((uint32_t)1<<(n))
 #define hashmask(n) (hashsize(n)-1)
 
 /*
@@ -164,12 +161,13 @@ acceptable.  Do NOT use for cryptographic purposes.
 --------------------------------------------------------------------
  */
 
-ub4 teoHashFast(k, length, initval)
-register ub1 *k; /* the key */
-register ub4 length; /* the length of the key */
-register ub4 initval; /* the previous hash, or an arbitrary value */
-{
-    register ub4 a, b, c, len;
+/*
+k the key
+length the length of the key
+initval the previous hash, or an arbitrary value
+*/
+uint32_t teoHashFast(register const uint8_t* k, register uint32_t length, register uint32_t initval) {
+    register uint32_t a, b, c, len;
 
     /* Set up the internal state */
     len = length;
@@ -178,9 +176,9 @@ register ub4 initval; /* the previous hash, or an arbitrary value */
 
     /*---------------------------------------- handle most of the key */
     while (len >= 12) {
-        a += (k[0] +((ub4) k[1] << 8) +((ub4) k[2] << 16) +((ub4) k[3] << 24));
-        b += (k[4] +((ub4) k[5] << 8) +((ub4) k[6] << 16) +((ub4) k[7] << 24));
-        c += (k[8] +((ub4) k[9] << 8) +((ub4) k[10] << 16)+((ub4) k[11] << 24));
+        a += (k[0] +((uint32_t) k[1] << 8) +((uint32_t) k[2] << 16) +((uint32_t) k[3] << 24));
+        b += (k[4] +((uint32_t) k[5] << 8) +((uint32_t) k[6] << 16) +((uint32_t) k[7] << 24));
+        c += (k[8] +((uint32_t) k[9] << 8) +((uint32_t) k[10] << 16)+((uint32_t) k[11] << 24));
         mix(a, b, c);
         k += 12;
         len -= 12;
@@ -189,17 +187,17 @@ register ub4 initval; /* the previous hash, or an arbitrary value */
     /*------------------------------------- handle the last 11 bytes */
     c += length;
     switch (len) /* all the case statements fall through */ {
-        case 11: c += ((ub4) k[10] << 24);
-        case 10: c += ((ub4) k[9] << 16);
-        case 9: c += ((ub4) k[8] << 8);
+        case 11: c += ((uint32_t) k[10] << 24);
+        case 10: c += ((uint32_t) k[9] << 16);
+        case 9: c += ((uint32_t) k[8] << 8);
             /* the first byte of c is reserved for the length */
-        case 8: b += ((ub4) k[7] << 24);
-        case 7: b += ((ub4) k[6] << 16);
-        case 6: b += ((ub4) k[5] << 8);
+        case 8: b += ((uint32_t) k[7] << 24);
+        case 7: b += ((uint32_t) k[6] << 16);
+        case 6: b += ((uint32_t) k[5] << 8);
         case 5: b += k[4];
-        case 4: a += ((ub4) k[3] << 24);
-        case 3: a += ((ub4) k[2] << 16);
-        case 2: a += ((ub4) k[1] << 8);
+        case 4: a += ((uint32_t) k[3] << 24);
+        case 3: a += ((uint32_t) k[2] << 16);
+        case 2: a += ((uint32_t) k[1] << 8);
         case 1: a += k[0];
             /* case 0: nothing left to add */
     }

--- a/src/teoccl/map.c
+++ b/src/teoccl/map.c
@@ -45,7 +45,7 @@ static
 teoMapElementData *_teoMapGetValueData(void *tqd_data, uint32_t key_length);
 
 static
-uint32_t _teopMapHash(void *key, size_t key_length);
+uint32_t _teopMapHash(const uint8_t *key, size_t key_length);
 
 static
 teoMap *_teoMapResize(teoMap *map, size_t size);
@@ -187,7 +187,7 @@ void teoMapClear(teoMap *map) {
  * @param key_length Key length
  * @return
  */
-static inline uint32_t _teopMapHash(void *key, size_t key_length) {
+static inline uint32_t _teopMapHash(const uint8_t *key, size_t key_length) {
 
     // Select one of several hash functions
     #define _USE_HASH_ 0

--- a/src/teoccl/map.c
+++ b/src/teoccl/map.c
@@ -243,16 +243,16 @@ static teoMapElementData *_teoMapGet(teoMap *map, const uint8_t *key, size_t key
  *
  * @return Pointer to Data of first available element or (void*)-1 if not found
  */
-void *teoMapGetFirst(teoMap *map, size_t *data_length) {
+uint8_t *teoMapGetFirst(teoMap *map, size_t *data_length) {
 
-    void *data = (void*)-1;
+    uint8_t *data = (uint8_t*)-1;
     if(data_length) *data_length = 0;
 
     teoMapIterator it;
     teoMapIteratorReset(&it, map);
 
-    teoMapElementData *el;
-    if((el = teoMapIteratorNext(&it))) {
+    teoMapElementData *el = teoMapIteratorNext(&it);
+    if(el != NULL) {
         data = teoMapIteratorElementData(el, data_length);
     }
 
@@ -279,10 +279,10 @@ static inline teoQueueData *_teoMapValueDataToQueueData(teoMapElementData *mvd) 
  * @param data_length Data length
  * @return Data of added key or (void*)-1 at error
  */
-void *teoMapAdd(teoMap *map, void *key, size_t key_length, void *data,
+uint8_t *teoMapAdd(teoMap *map, const uint8_t *key, size_t key_length, const uint8_t *data,
         size_t data_length) {
 
-    void *r_data = (void*)-1;
+    uint8_t *r_data = (uint8_t*)-1;
 
     if(!data) data_length = 0;
 
@@ -339,7 +339,7 @@ void *teoMapAdd(teoMap *map, void *key, size_t key_length, void *data,
  *
  * @return Data of selected key (may be NULL) or (void*)-1 if not found
  */
-void *teoMapGet(teoMap *map, void *key, size_t key_length,
+uint8_t *teoMapGet(teoMap *map, const uint8_t *key, size_t key_length,
         size_t *data_length) {
     uint8_t* data = (uint8_t*)-1;
     size_t element_data_length = 0;
@@ -367,7 +367,7 @@ void *teoMapGet(teoMap *map, void *key, size_t key_length,
  * @param key_length Key length
  * @return Zero at success, or errors: -1 - keys element not found
  */
-int teoMapDelete(teoMap *map, void *key, size_t key_length) {
+int teoMapDelete(teoMap *map, const uint8_t *key, size_t key_length) {
 
     int rv = -1;
 

--- a/tests/map_t.c
+++ b/tests/map_t.c
@@ -31,27 +31,27 @@ long long timeInMilliseconds(void) {
 void check_hash() {
 
     char *key = "127.0.0.1:8000";
-    uint32_t hash = teoHashSuperFast(key, strlen(key) + 1);
+    uint32_t hash = teoHashSuperFast((uint8_t*)key, strlen(key) + 1);
     printf("\n\tHash1 of key %s = %010u ", key, hash);
-    hash = teoHashFast((ub1*)key, strlen(key) + 1, 0);
+    hash = teoHashFast((uint8_t*)key, strlen(key) + 1, 0);
     printf("\n\tHash2 of key %s = %010u ", key, hash);
 
     key = "127.0.0.1:8001";
-    hash = teoHashSuperFast(key, strlen(key) + 1);
+    hash = teoHashSuperFast((uint8_t*)key, strlen(key) + 1);
     printf("\n\tHash1 of key %s = %010u ", key, hash);
-    hash = teoHashFast((ub1*)key, strlen(key) + 1, 0);
+    hash = teoHashFast((uint8_t*)key, strlen(key) + 1, 0);
     printf("\n\tHash2 of key %s = %010u ", key, hash);
 
     key = "192.168.101.11:8000";
-    hash = teoHashSuperFast(key, strlen(key) + 1);
+    hash = teoHashSuperFast((uint8_t*)key, strlen(key) + 1);
     printf("\n\tHash1 of key %s = %010u ", key, hash);
-    hash = teoHashFast((ub1*)key, strlen(key) + 1, 0);
+    hash = teoHashFast((uint8_t*)key, strlen(key) + 1, 0);
     printf("\n\tHash2 of key %s = %010u ", key, hash);
 
     key = "192.168.101.11:8001";
-    hash = teoHashSuperFast(key, strlen(key) + 1);
+    hash = teoHashSuperFast((uint8_t*)key, strlen(key) + 1);
     printf("\n\tHash1 of key %s = %010u ", key, hash);
-    hash = teoHashFast((ub1*)key, strlen(key) + 1, 0);
+    hash = teoHashFast((uint8_t*)key, strlen(key) + 1, 0);
     printf("\n\tHash2 of key %s = %010u \n   ", key, hash);
 
     CU_ASSERT(2 * 2 == 4);
@@ -118,11 +118,11 @@ void _check_map(const size_t NUM_KEYS) {
     for(i = 0; i < NUM_KEYS; i++) {
 
         // Add to map
-        teoMapAdd(map, key[i], key_length[i], data[i], data_length[i]);
+        teoMapAdd(map, (uint8_t*)key[i], key_length[i], (uint8_t*)data[i], data_length[i]);
 
         // Get from map
         size_t d_length;
-        void *d = teoMapGet(map, key[i], key_length[i], &d_length);
+        void *d = teoMapGet(map, (uint8_t*)key[i], key_length[i], &d_length);
         CU_ASSERT_FATAL(d != (void*)-1);
         CU_ASSERT_EQUAL_FATAL(data_length[i], d_length);
         CU_ASSERT_STRING_EQUAL(d, data[i]);
@@ -135,22 +135,22 @@ void _check_map(const size_t NUM_KEYS) {
     char *data_new = "This is new data for this key ...";
     size_t data_new_length = strlen(data_new) + 1;
     // Add to map
-    teoMapAdd(map, key[1], key_length[1], data_new, data_new_length);
+    teoMapAdd(map, (uint8_t*)key[1], key_length[1], (uint8_t*)data_new, data_new_length);
 
     // Get updated key from map
     size_t d_length;
-    void *d = teoMapGet(map, key[1], key_length[1], &d_length);
+    void *d = teoMapGet(map, (uint8_t*)key[1], key_length[1], &d_length);
     CU_ASSERT_FATAL(d != (void*)-1);
     CU_ASSERT_EQUAL_FATAL(data_new_length, d_length);
     CU_ASSERT_STRING_EQUAL(d, data_new);
 
     // Delete key from map
-    int rv = teoMapDelete(map, key[1], key_length[1]);
+    int rv = teoMapDelete(map, (uint8_t*)key[1], key_length[1]);
     CU_ASSERT(!rv);
     CU_ASSERT_EQUAL(NUM_KEYS - 1, teoMapSize(map));
 
     // Add deleted key
-    teoMapAdd(map, key[1], key_length[1], data[1], data_length[1]);
+    teoMapAdd(map, (uint8_t*)key[1], key_length[1], (uint8_t*)data[1], data_length[1]);
 
     // Loop through map using iterator
     t_beg = timeInMilliseconds();
@@ -224,11 +224,11 @@ void check_binary_key() {
     int data = 125;
 
     // Add to map
-    teoMapAdd(map, &key, sizeof(key) , &data, sizeof(data));
+    teoMapAdd(map, (uint8_t*)&key, sizeof(key) , (uint8_t*)&data, sizeof(data));
 
     // Get from map
     size_t d_length;
-    void *d = teoMapGet(map, &key, sizeof(key), &d_length);
+    void *d = teoMapGet(map, (uint8_t*)&key, sizeof(key), &d_length);
     CU_ASSERT_FATAL(d != (void*)-1);
     CU_ASSERT_EQUAL_FATAL(sizeof(data), d_length);
     CU_ASSERT_EQUAL(*(int*)d, data);
@@ -272,11 +272,11 @@ void check_map_delete() {
     for(i = 0; i < NUM_KEYS; i++) {
 
         // Add to map
-        teoMapAdd(map, key[i], key_length[i], data[i], data_length[i]);
+        teoMapAdd(map, (uint8_t*)key[i], key_length[i], (uint8_t*)data[i], data_length[i]);
 
         // Get from map
         size_t d_length;
-        void *d = teoMapGet(map, key[i], key_length[i], &d_length);
+        void *d = teoMapGet(map, (uint8_t*)key[i], key_length[i], &d_length);
         CU_ASSERT_FATAL(d != (void*)-1);
         CU_ASSERT_EQUAL_FATAL(data_length[i], d_length);
         CU_ASSERT_STRING_EQUAL(d, data[i]);
@@ -290,10 +290,10 @@ void check_map_delete() {
     int j;
     t_beg = timeInMilliseconds();
     for(i = NUM_KEYS - 1, j = 0; i >= 0; i--, j++) {
-        int rv = teoMapDelete(map, key[i], key_length[i]);
+        int rv = teoMapDelete(map, (uint8_t*)key[i], key_length[i]);
         CU_ASSERT(!rv);
         CU_ASSERT_EQUAL(NUM_KEYS - (j+1), teoMapSize(map));
-        rv = teoMapDelete(map, key[i], key_length[i]);
+        rv = teoMapDelete(map, (uint8_t*)key[i], key_length[i]);
         CU_ASSERT(rv);
         CU_ASSERT_EQUAL(NUM_KEYS - (j+1), teoMapSize(map));
     }


### PR DESCRIPTION
Changes in hash and map:
* Removed dangerous pointer arithmetic in map.
* Changed argument types in hash functions.
* Changed buffer pointers to `uint8_t*`
* Added `const` qualifiers to constant buffers.
