### PR TITLE
Fix SIZE_T_MAX is always equals to UINT_MAX.

### DIFF
--- a/src/teoccl/array_list.c
+++ b/src/teoccl/array_list.c
@@ -1,5 +1,5 @@
-#include <stdlib.h>
 #include <limits.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "teoccl/array_list.h"
@@ -7,15 +7,7 @@
 #include "teoccl/memory.h"
 
 #ifndef SIZE_T_MAX
-  #if SIZEOF_SIZE_T == SIZEOF_INT
-    #define SIZE_T_MAX UINT_MAX
-  #elif SIZEOF_SIZE_T == SIZEOF_LONG
-    #define SIZE_T_MAX ULONG_MAX
-  #elif SIZEOF_SIZE_T == SIZEOF_LONG_LONG
-    #define SIZE_T_MAX ULLONG_MAX
-  #else
-    #error Unable to determine size of size_t
-  #endif
+  #define SIZE_T_MAX ((size_t)-1)
 #endif
 
 ccl_array_list_t *cclArrayListNew(array_list_free_fn *free_fn)

--- a/src/teoccl/linked_list.c
+++ b/src/teoccl/linked_list.c
@@ -6,15 +6,7 @@
 #include "teoccl/linked_list.h"
 
 #ifndef SIZE_T_MAX
-  #if SIZEOF_SIZE_T == SIZEOF_INT
-    #define SIZE_T_MAX UINT_MAX
-  #elif SIZEOF_SIZE_T == SIZEOF_LONG
-    #define SIZE_T_MAX ULONG_MAX
-  #elif SIZEOF_SIZE_T == SIZEOF_LONG_LONG
-    #define SIZE_T_MAX ULLONG_MAX
-  #else
-    #error Unable to determine size of size_t
-  #endif
+  #define SIZE_T_MAX ((size_t)-1)
 #endif
 
 struct ccl_linked_list {

--- a/src/teoccl/list.c
+++ b/src/teoccl/list.c
@@ -6,15 +6,7 @@
 #include "teoccl/list.h"
 
 #ifndef SIZE_T_MAX
-  #if SIZEOF_SIZE_T == SIZEOF_INT
-    #define SIZE_T_MAX UINT_MAX
-  #elif SIZEOF_SIZE_T == SIZEOF_LONG
-    #define SIZE_T_MAX ULONG_MAX
-  #elif SIZEOF_SIZE_T == SIZEOF_LONG_LONG
-    #define SIZE_T_MAX ULLONG_MAX
-  #else
-    #error Unable to determine size of size_t
-  #endif
+  #define SIZE_T_MAX ((size_t)-1)
 #endif
 
 struct ccl_list {


### PR DESCRIPTION
SIZEOF_SIZE_T is not defined on Windows. This was not triggering compilation error but SIZE_T_MAX was always equals to UINT_MAX on Windows.

###EDIT
SIZEOF_SIZE_T is not defined in GCC too. SIZE_T_MAX was always equals to UINT_MAX on all platforms.

Since we don't really care about maximum object size, but we want to know maximum value that can be stored in size_t, I decided to define it to ((size_t)-1).